### PR TITLE
feat: 토큰 재발급, 로그아웃 API

### DIFF
--- a/src/main/java/com/dayaeyak/auth/common/config/RedisConfig.java
+++ b/src/main/java/com/dayaeyak/auth/common/config/RedisConfig.java
@@ -6,6 +6,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -27,5 +30,15 @@ public class RedisConfig {
         redisStandaloneConfiguration.setPassword(password);
 
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+
+        return template;
     }
 }

--- a/src/main/java/com/dayaeyak/auth/common/constraints/AuthResponseMessage.java
+++ b/src/main/java/com/dayaeyak/auth/common/constraints/AuthResponseMessage.java
@@ -4,4 +4,6 @@ public class AuthResponseMessage {
 
     public static final String SIGNUP_SUCCESS = "회원가입이 완료되었습니다.";
     public static final String LOGIN_SUCCESS = "로그인 되었습니다.";
+    public static final String REISSUE_SUCCESS = "재발급이 완료되었습니다.";
+    public static final String LOGOUT_SUCCESS = "로그아웃 되었습니다.";
 }

--- a/src/main/java/com/dayaeyak/auth/common/constraints/AuthValidationMessage.java
+++ b/src/main/java/com/dayaeyak/auth/common/constraints/AuthValidationMessage.java
@@ -31,4 +31,7 @@ public class AuthValidationMessage {
 
     // role
     public static final String INVALID_ROLE_MESSAGE = "권한을 입력해주세요.";
+
+    // refresh token
+    public static final String INVALID_REFRESH_TOKEN_MESSAGE = "유효한 토큰을 입력해주세요.";
 }

--- a/src/main/java/com/dayaeyak/auth/common/entity/ApiResponse.java
+++ b/src/main/java/com/dayaeyak/auth/common/entity/ApiResponse.java
@@ -9,6 +9,11 @@ public record ApiResponse<T>(
         T data
 ) {
 
+    public static ResponseEntity<ApiResponse<Void>> success(HttpStatus status, String message) {
+        return ResponseEntity.status(status.value())
+                .body(new ApiResponse<>(message, null));
+    }
+
     public static <T> ResponseEntity<ApiResponse<T>> success(HttpStatus status, String message, T data) {
         return ResponseEntity.status(status.value())
                 .body(new ApiResponse<>(message, data));

--- a/src/main/java/com/dayaeyak/auth/common/exception/type/AuthExceptionType.java
+++ b/src/main/java/com/dayaeyak/auth/common/exception/type/AuthExceptionType.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthExceptionType implements ExceptionType {
 
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디나 비밀번호가 잘못되었습니다."),
     INVALID_USER_ROLE(HttpStatus.UNAUTHORIZED, "유효하지 않은 유저 권한입니다.")
     ;

--- a/src/main/java/com/dayaeyak/auth/domain/auth/AuthController.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/AuthController.java
@@ -3,8 +3,11 @@ package com.dayaeyak.auth.domain.auth;
 import com.dayaeyak.auth.common.constraints.AuthResponseMessage;
 import com.dayaeyak.auth.common.entity.ApiResponse;
 import com.dayaeyak.auth.domain.auth.dto.request.AuthLoginRequestDto;
+import com.dayaeyak.auth.domain.auth.dto.request.AuthLogoutRequestDto;
+import com.dayaeyak.auth.domain.auth.dto.request.AuthReissueRequestDto;
 import com.dayaeyak.auth.domain.auth.dto.request.AuthSignupRequestDto;
 import com.dayaeyak.auth.domain.auth.dto.response.AuthLoginResponseDto;
+import com.dayaeyak.auth.domain.auth.dto.response.AuthReissueResponseDto;
 import com.dayaeyak.auth.domain.auth.dto.response.AuthSignupResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,5 +41,23 @@ public class AuthController {
         AuthLoginResponseDto data = authService.login(authLoginRequestDto);
 
         return ApiResponse.success(HttpStatus.OK, AuthResponseMessage.LOGIN_SUCCESS, data);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<AuthReissueResponseDto>> reissue(
+            @RequestBody @Valid AuthReissueRequestDto authReissueRequestDto
+    ) {
+        AuthReissueResponseDto data = authService.reissueAccessToken(authReissueRequestDto);
+
+        return ApiResponse.success(HttpStatus.OK, AuthResponseMessage.REISSUE_SUCCESS, data);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @RequestBody @Valid AuthLogoutRequestDto authLogoutRequestDto
+    ) {
+        authService.logout(authLogoutRequestDto);
+
+        return ApiResponse.success(HttpStatus.OK, AuthResponseMessage.LOGOUT_SUCCESS);
     }
 }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/AuthService.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.dayaeyak.auth.domain.auth;
 
+import com.dayaeyak.auth.common.exception.CustomRuntimeException;
 import com.dayaeyak.auth.common.exception.type.AuthExceptionType;
 import com.dayaeyak.auth.common.util.JwtProvider;
 import com.dayaeyak.auth.domain.auth.cache.redis.AuthRedisRepository;
@@ -7,10 +8,13 @@ import com.dayaeyak.auth.domain.auth.client.user.UserFeignClient;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserCreateRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserFindByEmailRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserCreateResponseDto;
-import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindByEmailResponseDto;
+import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindResponseDto;
 import com.dayaeyak.auth.domain.auth.dto.request.AuthLoginRequestDto;
+import com.dayaeyak.auth.domain.auth.dto.request.AuthLogoutRequestDto;
+import com.dayaeyak.auth.domain.auth.dto.request.AuthReissueRequestDto;
 import com.dayaeyak.auth.domain.auth.dto.request.AuthSignupRequestDto;
 import com.dayaeyak.auth.domain.auth.dto.response.AuthLoginResponseDto;
+import com.dayaeyak.auth.domain.auth.dto.response.AuthReissueResponseDto;
 import com.dayaeyak.auth.domain.auth.dto.response.AuthSignupResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -46,11 +50,11 @@ public class AuthService {
 
     public AuthLoginResponseDto login(AuthLoginRequestDto dto) {
         // Find user by email
-        UserFindByEmailResponseDto user = userFeignClient.findUserByEmail(UserFindByEmailRequestDto.from(dto));
+        UserFindResponseDto user = userFeignClient.findUserByEmail(UserFindByEmailRequestDto.from(dto));
 
         // validate user password
         if (!passwordEncoder.matches(dto.password(), user.password())) {
-            throw new RuntimeException(AuthExceptionType.INVALID_CREDENTIALS.getMessage());
+            throw new CustomRuntimeException(AuthExceptionType.INVALID_CREDENTIALS);
         }
 
         // generate tokens
@@ -61,5 +65,27 @@ public class AuthService {
         authRedisRepository.saveRefreshToken(refreshToken, user.userId());
 
         return AuthLoginResponseDto.from(accessToken, refreshToken);
+    }
+
+    public AuthReissueResponseDto reissueAccessToken(AuthReissueRequestDto dto) {
+        Long userId = authRedisRepository.findAndDeleteByRefreshToken(dto.refreshToken())
+                .orElseThrow(() -> new CustomRuntimeException(AuthExceptionType.INVALID_TOKEN));
+
+        UserFindResponseDto user = userFeignClient.findUserById(userId);
+
+        String accessToken = jwtProvider.generateAccessToken(user.userId(), user.role());
+        String refreshToken = jwtProvider.generateRefreshToken(user.userId());
+
+        authRedisRepository.saveRefreshToken(refreshToken, user.userId());
+
+        return AuthReissueResponseDto.from(accessToken, refreshToken);
+    }
+
+    public void logout(AuthLogoutRequestDto dto) {
+        boolean isDeleted = authRedisRepository.deleteByRefreshToken(dto.refreshToken());
+
+        if (!isDeleted) {
+            throw new CustomRuntimeException(AuthExceptionType.INVALID_TOKEN);
+        }
     }
 }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/cache/redis/AuthRedisRepository.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/cache/redis/AuthRedisRepository.java
@@ -1,6 +1,12 @@
 package com.dayaeyak.auth.domain.auth.cache.redis;
 
+import java.util.Optional;
+
 public interface AuthRedisRepository {
 
     void saveRefreshToken(String refreshToken, Long userId);
+
+    Optional<Long> findAndDeleteByRefreshToken(String refreshToken);
+
+    boolean deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/cache/redis/AuthRedisRepositoryImpl.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/cache/redis/AuthRedisRepositoryImpl.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -14,11 +15,24 @@ public class AuthRedisRepositoryImpl implements AuthRedisRepository {
     @Value("${jwt.refresh.expiration}")
     private long refreshExpiration;
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, Long> redisTemplate;
 
     @Override
     public void saveRefreshToken(String refreshToken, Long userId) {
         redisTemplate.opsForValue()
-                .set(refreshToken, userId.toString(), Duration.ofMillis(refreshExpiration));
+                .set(refreshToken, userId, Duration.ofMillis(refreshExpiration));
+    }
+
+    @Override
+    public Optional<Long> findAndDeleteByRefreshToken(String refreshToken) {
+        Long userId = redisTemplate.opsForValue()
+                .getAndDelete(refreshToken);
+
+        return Optional.ofNullable(userId);
+    }
+
+    @Override
+    public boolean deleteByRefreshToken(String refreshToken) {
+        return redisTemplate.delete(refreshToken);
     }
 }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/client/user/UserFeignClient.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/client/user/UserFeignClient.java
@@ -3,8 +3,10 @@ package com.dayaeyak.auth.domain.auth.client.user;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserCreateRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserFindByEmailRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserCreateResponseDto;
-import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindByEmailResponseDto;
+import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -19,5 +21,8 @@ public interface UserFeignClient {
     UserCreateResponseDto createUser(@RequestBody UserCreateRequestDto request);
 
     @PostMapping("/find-user")
-    UserFindByEmailResponseDto findUserByEmail(@RequestBody UserFindByEmailRequestDto request);
+    UserFindResponseDto findUserByEmail(@RequestBody UserFindByEmailRequestDto request);
+
+    @GetMapping("/{userId}")
+    UserFindResponseDto findUserById(@PathVariable Long userId);
 }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/client/user/UserFeignClientFallbackFactory.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/client/user/UserFeignClientFallbackFactory.java
@@ -6,7 +6,7 @@ import com.dayaeyak.auth.common.exception.type.UserExceptionType;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserCreateRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.request.UserFindByEmailRequestDto;
 import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserCreateResponseDto;
-import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindByEmailResponseDto;
+import com.dayaeyak.auth.domain.auth.client.user.dto.response.UserFindResponseDto;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.openfeign.FallbackFactory;
@@ -33,7 +33,19 @@ public class UserFeignClientFallbackFactory implements FallbackFactory<UserFeign
             }
 
             @Override
-            public UserFindByEmailResponseDto findUserByEmail(UserFindByEmailRequestDto request) {
+            public UserFindResponseDto findUserByEmail(UserFindByEmailRequestDto request) {
+                if (cause instanceof FeignException.NotFound e) {
+                    String message = e.contentUTF8();
+                    HttpStatus httpStatus = HttpStatus.valueOf(e.status());
+
+                    throw new CustomInternalException(httpStatus, message);
+                }
+
+                throw new CustomRuntimeException(UserExceptionType.USER_SERVICE_UNAVAILABLE);
+            }
+
+            @Override
+            public UserFindResponseDto findUserById(Long userId) {
                 if (cause instanceof FeignException.NotFound e) {
                     String message = e.contentUTF8();
                     HttpStatus httpStatus = HttpStatus.valueOf(e.status());

--- a/src/main/java/com/dayaeyak/auth/domain/auth/client/user/dto/response/UserFindResponseDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/client/user/dto/response/UserFindResponseDto.java
@@ -2,7 +2,7 @@ package com.dayaeyak.auth.domain.auth.client.user.dto.response;
 
 import com.dayaeyak.auth.domain.auth.enums.UserRole;
 
-public record UserFindByEmailResponseDto(
+public record UserFindResponseDto(
         Long userId,
 
         String password,

--- a/src/main/java/com/dayaeyak/auth/domain/auth/dto/request/AuthLogoutRequestDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/dto/request/AuthLogoutRequestDto.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.auth.domain.auth.dto.request;
+
+import com.dayaeyak.auth.common.constraints.AuthValidationMessage;
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthLogoutRequestDto(
+        @NotBlank(message = AuthValidationMessage.INVALID_REFRESH_TOKEN_MESSAGE)
+        String refreshToken
+) {
+}

--- a/src/main/java/com/dayaeyak/auth/domain/auth/dto/request/AuthReissueRequestDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/dto/request/AuthReissueRequestDto.java
@@ -1,0 +1,10 @@
+package com.dayaeyak.auth.domain.auth.dto.request;
+
+import com.dayaeyak.auth.common.constraints.AuthValidationMessage;
+import jakarta.validation.constraints.NotBlank;
+
+public record AuthReissueRequestDto(
+        @NotBlank(message = AuthValidationMessage.INVALID_REFRESH_TOKEN_MESSAGE)
+        String refreshToken
+) {
+}

--- a/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthLoginResponseDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthLoginResponseDto.java
@@ -5,6 +5,7 @@ public record AuthLoginResponseDto(
 
         String refreshToken
 ) {
+
     public static AuthLoginResponseDto from(String accessToken, String refreshToken) {
         return new AuthLoginResponseDto(accessToken, refreshToken);
     }

--- a/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthReissueResponseDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthReissueResponseDto.java
@@ -1,0 +1,12 @@
+package com.dayaeyak.auth.domain.auth.dto.response;
+
+public record AuthReissueResponseDto(
+        String accessToken,
+
+        String refreshToken
+) {
+
+    public static AuthReissueResponseDto from(String accessToken, String refreshToken) {
+        return new AuthReissueResponseDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthSignupResponseDto.java
+++ b/src/main/java/com/dayaeyak/auth/domain/auth/dto/response/AuthSignupResponseDto.java
@@ -7,7 +7,6 @@ public record AuthSignupResponseDto(
 ) {
 
     public static AuthSignupResponseDto from(String accessToken, String refreshToken) {
-        return new AuthSignupResponseDto(accessToken, refreshToken)
-                ;
+        return new AuthSignupResponseDto(accessToken, refreshToken);
     }
 }


### PR DESCRIPTION
## 📝 요약(Summary)

토큰 재발급 API, 로그아웃 API 추가

## 💫 구현 및 변경 사항 (Details)

토큰 재발급 API
- `RefreshToken`을 요청 바디 값으로 보내 `AccessToken`과 `RefreshToken` 재발급
로그아웃 API
- 저장된 `RefreshToken`삭제
- `AccessToken`은 만료기간 짧게 설정해서 굳이 블랙리스트 등록 X


## 📸스크린샷 (선택)

## ✅ 체크리스트

- [x] 코드 정상 작동 테스트 완료
- [x] 관련 문서(API 문서, 위키 등) 업데이트
- [x] 팀의 코드 컨벤션/스타일 가이드 준수
- [x] Reviewers에 팀원 등록


## 💬 TODO ( 미완성일 경우 )

## 기타/주의사항